### PR TITLE
Moved MAM acronym

### DIFF
--- a/lib/smart_answer_flows/towing-rules/outcomes/limited_trailer_entitlement_2013.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/limited_trailer_entitlement_2013.govspeak.erb
@@ -1,11 +1,11 @@
 <% content_for :body do %>
   You can already tow trailers up to 750kg.
 
-  You can also tow heavier trailers if combined weight of trailer and vehicle isn’t more than 3,500kg.
+  You can also tow heavier trailers if combined weight of trailer and vehicle isn’t more than 3,500kg maximum authorised mass (MAM).
 
   ##Category BE entitlement
 
-  If you have the category BE towing with a car entitlement you can tow trailers up to 3,500kg maximum authorised mass (MAM).
+  If you have the category BE towing with a car entitlement you can tow trailers up to 3,500kg MAM.
 
   ###Trailers over 3,500kg
 


### PR DESCRIPTION
Moved 'maximum authorised mass (MAM).' from the end of the 3rd sentence to the end of the 2nd sentence.
Added MAM to the end of the third sentence.
https://trello.com/c/DbiKgBtr/739-towing-rules-and-mam